### PR TITLE
feat: 도메인 패키지 생성 및 엔티티 구현

### DIFF
--- a/src/main/java/com/teamh/khumon/KhumonApplication.java
+++ b/src/main/java/com/teamh/khumon/KhumonApplication.java
@@ -2,7 +2,9 @@ package com.teamh.khumon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class KhumonApplication {
 

--- a/src/main/java/com/teamh/khumon/domain/LearningMaterial.java
+++ b/src/main/java/com/teamh/khumon/domain/LearningMaterial.java
@@ -1,0 +1,41 @@
+package com.teamh.khumon.domain;
+
+
+import com.teamh.khumon.domain.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@ToString(callSuper = true)
+@Table(name = "learning_material")
+public class LearningMaterial extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private MediaFileType mediaFileType;
+
+    @Column(nullable = false, unique = true)
+    private String fileName;
+
+    @Column(nullable = false, unique = true)
+    private String fileURL;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    @ToString.Exclude
+    private Member member;
+
+    @OneToMany(mappedBy = "learningMaterial", fetch = FetchType.LAZY)
+    @ToString.Exclude
+    List<Question> questions = new ArrayList<>();
+
+}

--- a/src/main/java/com/teamh/khumon/domain/MediaFileType.java
+++ b/src/main/java/com/teamh/khumon/domain/MediaFileType.java
@@ -1,0 +1,20 @@
+package com.teamh.khumon.domain;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@RequiredArgsConstructor
+@Getter
+public enum MediaFileType {
+
+    PDF("PDF"),
+    TEXT("TEXT"),
+    VIDEO("VIDEO"),
+    ETC("ETC");
+
+    private final String fileType;
+
+}

--- a/src/main/java/com/teamh/khumon/domain/Member.java
+++ b/src/main/java/com/teamh/khumon/domain/Member.java
@@ -1,0 +1,87 @@
+package com.teamh.khumon.domain;
+
+
+import com.teamh.khumon.domain.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@ToString(callSuper = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "member")
+@Builder
+public class Member extends BaseEntity implements UserDetails {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private String role = "ROLE_USER";
+
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(this.getRole()));
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+    @ToString.Exclude
+    private List<LearningMaterial> learningMaterials = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+    @ToString.Exclude
+    private List<Question> questions = new ArrayList<>();
+
+
+}

--- a/src/main/java/com/teamh/khumon/domain/Question.java
+++ b/src/main/java/com/teamh/khumon/domain/Question.java
@@ -1,0 +1,33 @@
+package com.teamh.khumon.domain;
+
+
+import com.teamh.khumon.domain.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@ToString(callSuper = true)
+@Table(name = "question")
+public class Question extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    @ToString.Exclude
+    private Member member;
+
+    @ManyToOne()
+    @JoinColumn(name = "learning_material_id")
+    @ToString.Exclude
+    private LearningMaterial learningMaterial;
+}

--- a/src/main/java/com/teamh/khumon/domain/base/BaseEntity.java
+++ b/src/main/java/com/teamh/khumon/domain/base/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.teamh.khumon.domain.base;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updateAt;
+
+}


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #5 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
ERD 설계에 따른 엔티티들을 구현하였습니다. 각 연관관계에서 fetch 전략은 Lazy로 두었으며, JPAAuditing을 적용하기 위해 BaseEntity을 따로 구현한 뒤, 각각의 엔티티들이 상속받아 자동으로 필드에 속하도록 구현하였습니다. 
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
