### PR TITLE
feat: 소셜 로그인 인증/인가 기능을 구현한다. 

### DIFF
--- a/src/main/java/com/teamh/khumon/domain/LearningMaterial.java
+++ b/src/main/java/com/teamh/khumon/domain/LearningMaterial.java
@@ -10,8 +10,8 @@ import java.util.List;
 
 @Entity
 @Getter
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 @ToString(callSuper = true)
 @Table(name = "learning_material")

--- a/src/main/java/com/teamh/khumon/domain/Member.java
+++ b/src/main/java/com/teamh/khumon/domain/Member.java
@@ -14,8 +14,8 @@ import java.util.List;
 
 @Getter
 @ToString(callSuper = true)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@NoArgsConstructor
 @Entity
 @Table(name = "member")
 @Builder
@@ -24,11 +24,12 @@ public class Member extends BaseEntity implements UserDetails {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String username; //OAuth2 고유 식별자
 
 
-    @Column(nullable = false, unique = true)
+
+    @Column(nullable = false)
     private String nickname;
 
 

--- a/src/main/java/com/teamh/khumon/domain/OAuth2Provider.java
+++ b/src/main/java/com/teamh/khumon/domain/OAuth2Provider.java
@@ -1,7 +1,14 @@
 package com.teamh.khumon.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
 public enum OAuth2Provider {
-    KAKAO,
-    GOOGLE,
-    NAVER;
+    KAKAO("KAKAO"),
+    GOOGLE("GOOGLE"),
+    NAVER("NAVER");
+
+    private final String provider;
 }

--- a/src/main/java/com/teamh/khumon/domain/Question.java
+++ b/src/main/java/com/teamh/khumon/domain/Question.java
@@ -7,8 +7,8 @@ import lombok.*;
 
 @Entity
 @Getter
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 @ToString(callSuper = true)
 @Table(name = "question")

--- a/src/main/java/com/teamh/khumon/dto/CustomOAuth2User.java
+++ b/src/main/java/com/teamh/khumon/dto/CustomOAuth2User.java
@@ -1,0 +1,22 @@
+package com.teamh.khumon.dto;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+    private String role;
+
+    private String username;
+
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities, Map<String, Object> attributes, String nameAttributeKey,String username, String role) {
+        super(authorities, attributes, nameAttributeKey);
+        this.role = role;
+        this.username = username;
+
+    }
+}

--- a/src/main/java/com/teamh/khumon/dto/GoogleUserInformation.java
+++ b/src/main/java/com/teamh/khumon/dto/GoogleUserInformation.java
@@ -1,0 +1,25 @@
+package com.teamh.khumon.dto;
+
+import java.util.Map;
+
+public class GoogleUserInformation extends Oauth2UserInformation{
+
+    private String id;
+    private String nickname;
+    public GoogleUserInformation(Map<String, Object> attributes) {
+        super(attributes);
+        this.id = (String) attributes.get("sub");
+        this.nickname = (String) attributes.get("name");
+
+    }
+
+    @Override
+    public String getIdentifierKey() {
+        return this.id;
+    }
+
+    @Override
+    public String getNickname() {
+        return this.nickname;
+    }
+}

--- a/src/main/java/com/teamh/khumon/dto/KakaoUserInformation.java
+++ b/src/main/java/com/teamh/khumon/dto/KakaoUserInformation.java
@@ -1,0 +1,27 @@
+package com.teamh.khumon.dto;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class KakaoUserInformation extends Oauth2UserInformation{
+
+    private String id;
+    private String nickname;
+
+    public KakaoUserInformation(Map<String, Object> attributes) {
+        super(attributes);
+        this.id = String.valueOf(attributes.get("id"));
+        Optional<Map<String, Object>> account = Optional.ofNullable((Map<String, Object>) attributes.get("kakao_account"));
+        this.nickname = account.map(stringObjectMap -> (Map<String, Object>) account.get().get("profile")).map(stringObjectMap -> (String) stringObjectMap.get("nickname")).orElse(null);
+    }
+
+    @Override
+    public String getIdentifierKey() {
+        return this.id;
+    }
+
+    @Override
+    public String getNickname() {
+        return this.nickname;
+    }
+}

--- a/src/main/java/com/teamh/khumon/dto/NaverUserInformation.java
+++ b/src/main/java/com/teamh/khumon/dto/NaverUserInformation.java
@@ -1,0 +1,35 @@
+package com.teamh.khumon.dto;
+
+import com.nimbusds.jose.shaded.gson.JsonObject;
+import com.nimbusds.jose.shaded.gson.JsonParser;
+import com.teamh.khumon.security.OAuth2Attributes;
+import org.apache.tomcat.util.json.JSONParser;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class NaverUserInformation extends Oauth2UserInformation {
+
+    private String id;
+    private String nickname;
+
+
+    public NaverUserInformation(Map<String, Object> attributes) {
+        super(attributes);
+        Optional<Map<String, Object>> response = Optional.ofNullable( (Map<String, Object>) attributes.get("response"));
+        this.id = response.map(stringObjectMap -> (String) stringObjectMap.get("id")).orElse(null);
+        this.nickname = response.map(stringObjectMap -> (String) stringObjectMap.get("nickname")).orElse(null);
+    }
+
+    @Override
+    public String getIdentifierKey() {
+      return this.id;
+
+    }
+
+    @Override
+    public String getNickname() {
+        return this.nickname;
+    }
+}

--- a/src/main/java/com/teamh/khumon/dto/Oauth2UserInformation.java
+++ b/src/main/java/com/teamh/khumon/dto/Oauth2UserInformation.java
@@ -1,0 +1,21 @@
+package com.teamh.khumon.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public abstract class Oauth2UserInformation {
+    protected Map<String, Object> attributes;
+
+    public abstract String getIdentifierKey();
+    //google : sub
+    //naver : id
+    //kakao : id
+
+    public abstract String  getNickname();
+
+}

--- a/src/main/java/com/teamh/khumon/repository/MemberRepository.java
+++ b/src/main/java/com/teamh/khumon/repository/MemberRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByUsername(String username);
+    Optional<Member> findByUsername(String name);
 }

--- a/src/main/java/com/teamh/khumon/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/teamh/khumon/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,35 @@
+package com.teamh.khumon.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.configurationprocessor.json.JSONException;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    //권한이 없는 유저가 접근 할 시 처리하는 핸들러
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException)
+            throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setContentType("application/json;charset=UTF-8");
+        JSONObject responseJson = new JSONObject();
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        try {
+            responseJson.put("message", "엑세스 권한이 없습니다.");
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+        response.getWriter().write(objectMapper.writeValueAsString(responseJson));
+    }
+}

--- a/src/main/java/com/teamh/khumon/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/teamh/khumon/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,40 @@
+package com.teamh.khumon.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.configurationprocessor.json.JSONException;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+
+        log.info("인증 실패");
+        try {
+            setResponse(response);
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException, JSONException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setContentType("application/json;charset=UTF-8");
+        JSONObject responseJson = new JSONObject();
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        responseJson.put("message", "인증이 실패했습니다.");
+        response.getWriter().write(objectMapper.writeValueAsString(responseJson));
+    }
+}

--- a/src/main/java/com/teamh/khumon/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/teamh/khumon/security/JwtAuthenticationFilter.java
@@ -23,13 +23,16 @@ import java.io.IOException;
 import java.util.Optional;
 
 
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 
 
 
-@RequiredArgsConstructor
+
 @Slf4j
+@Component
+@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 

--- a/src/main/java/com/teamh/khumon/security/OAuth2Attributes.java
+++ b/src/main/java/com/teamh/khumon/security/OAuth2Attributes.java
@@ -1,0 +1,90 @@
+package com.teamh.khumon.security;
+
+
+
+import com.teamh.khumon.domain.Member;
+import com.teamh.khumon.domain.OAuth2Provider;
+import com.teamh.khumon.dto.GoogleUserInformation;
+import com.teamh.khumon.dto.KakaoUserInformation;
+import com.teamh.khumon.dto.NaverUserInformation;
+import com.teamh.khumon.dto.Oauth2UserInformation;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+
+
+@Getter
+@Slf4j
+public class OAuth2Attributes {
+
+    private String nameAttributeKey; // OAuth2 로그인 진행 시 키가 되는 필드 값, PK와 같은 의미
+    private Oauth2UserInformation oauth2UserInfo; // 소셜 타입별 로그인 유저 정보(닉네임, 이메일, 프로필 사진 등등)
+
+    @Builder
+    public OAuth2Attributes(String nameAttributeKey, Oauth2UserInformation oauth2UserInfo) {
+        this.nameAttributeKey = nameAttributeKey;
+        this.oauth2UserInfo = oauth2UserInfo;
+    }
+
+    /**
+     * SocialType에 맞는 메소드 호출하여 OAuthAttributes 객체 반환
+     * 파라미터 : userNameAttributeName -> OAuth2 로그인 시 키(PK)가 되는 값 / attributes : OAuth 서비스의 유저 정보들
+     * 소셜별 of 메소드(ofGoogle, ofKaKao, ofNaver)들은 각각 소셜 로그인 API에서 제공하는
+     * 회원의 식별값(id), attributes, nameAttributeKey를 저장 후 build
+     */
+    public static OAuth2Attributes of(OAuth2Provider socialType,
+                                      String userNameAttributeName, Map<String ,Object> attributes) {
+
+        if (socialType == OAuth2Provider.NAVER) {
+            log.info("네이버 로그인임");
+            return ofNaver(userNameAttributeName, attributes);
+        }
+        if (socialType == OAuth2Provider.KAKAO) {
+            log.info("카카오 로그인임");
+            return ofKakao(userNameAttributeName, attributes);
+        }
+        log.info("구글 로그인임");
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuth2Attributes ofKakao(String userNameAttributeName, Map<String ,Object> attributes) {
+        return OAuth2Attributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new KakaoUserInformation(attributes))
+                .build();
+    }
+
+    public static OAuth2Attributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuth2Attributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new GoogleUserInformation(attributes))
+                .build();
+    }
+
+    public static OAuth2Attributes ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+        log.info("attributes : " + attributes.toString());
+        return OAuth2Attributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new NaverUserInformation(attributes))
+                .build();
+    }
+
+
+
+    /**
+     * of메소드로 OAuthAttributes 객체가 생성되어, 유저 정보들이 담긴 OAuth2UserInfo가 소셜 타입별로 주입된 상태
+     * OAuth2UserInfo에서 socialId(식별값), nickname, imageUrl을 가져와서 build
+     * email에는 UUID로 중복 없는 랜덤 값 생성
+     * role은 GUEST로 설정
+     */
+    public Member toEntity(OAuth2Provider oAuth2Provider, Oauth2UserInformation oauth2UserInfo) {
+        return Member.builder()
+                .oAuth2Provider(oAuth2Provider)
+                .username(oauth2UserInfo.getIdentifierKey())
+                .nickname(oauth2UserInfo.getNickname())
+                .role("ROLE_USER")
+                .build();
+    }
+}

--- a/src/main/java/com/teamh/khumon/security/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/teamh/khumon/security/OAuth2LoginFailureHandler.java
@@ -1,0 +1,36 @@
+package com.teamh.khumon.security;
+
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.configurationprocessor.json.JSONException;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        JSONObject jsonObject = new JSONObject();
+        log.info("소셜 로그인 실패");
+        try {
+            jsonObject.put("message", "소셜 로그인 실패");
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+        response.getWriter().write(objectMapper.writeValueAsString(jsonObject));
+    }
+}

--- a/src/main/java/com/teamh/khumon/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/teamh/khumon/security/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,73 @@
+package com.teamh.khumon.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teamh.khumon.domain.Member;
+import com.teamh.khumon.dto.CustomOAuth2User;
+import com.teamh.khumon.repository.MemberRepository;
+import com.teamh.khumon.service.JwtProviderService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtProviderService jwtProviderService;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        log.info("소셜 로그인 성공");
+        String username = extractUsername(authentication);
+        String accessToken = jwtProviderService.generateAccessToken(username, "ROLE_USER");
+
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json;charset=UTF-8");
+
+        Member member = memberRepository.findByUsername(username).get();
+
+        String uri = createURI(accessToken, member.getId(), member.getNickname()).toString();
+        // Access Token과 Refresh Token을 포함한 URL을 생성
+        response.sendRedirect(uri);   // sendRedirect() 메서드를 이용해 Frontend 애플리케이션 쪽으로 리다이렉트
+    }
+
+
+    private String extractUsername(Authentication authentication) {
+        log.info(authentication.toString());
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        log.info(oAuth2User.getUsername());
+        return oAuth2User.getUsername();
+    }
+
+    private URI createURI(String accessToken,  Long userId, String nickname) throws UnsupportedEncodingException {
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add("id", String.valueOf(userId));
+        queryParams.add("access-token", accessToken);
+
+        return UriComponentsBuilder
+                .newInstance()
+                .scheme("http")
+                .host("localhost")
+                .port(3000)
+                .path("/oauth2/login")
+                .queryParams(queryParams)
+                .build()
+                .toUri();
+    }
+}

--- a/src/main/java/com/teamh/khumon/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/teamh/khumon/security/OAuth2LoginSuccessHandler.java
@@ -43,7 +43,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         Member member = memberRepository.findByUsername(username).get();
 
         String uri = createURI(accessToken, member.getId(), member.getNickname()).toString();
-        // Access Token과 Refresh Token을 포함한 URL을 생성
         response.sendRedirect(uri);   // sendRedirect() 메서드를 이용해 Frontend 애플리케이션 쪽으로 리다이렉트
     }
 

--- a/src/main/java/com/teamh/khumon/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/teamh/khumon/service/CustomOAuth2UserService.java
@@ -1,0 +1,89 @@
+package com.teamh.khumon.service;
+
+
+import com.teamh.khumon.domain.Member;
+import com.teamh.khumon.domain.OAuth2Provider;
+import com.teamh.khumon.dto.CustomOAuth2User;
+import com.teamh.khumon.repository.MemberRepository;
+import com.teamh.khumon.security.OAuth2Attributes;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final MemberRepository memberRepository;
+
+    private static final String NAVER = "naver";
+    private static final String KAKAO = "kakao";
+
+    @Transactional
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        log.info("Oauth2User : " + oAuth2User.toString());
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        log.info("registrationId : " + registrationId);
+        OAuth2Provider oAuth2Provider = getSocialType(registrationId);
+        log.info("oauth2Provider : " + oAuth2Provider);
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        OAuth2Attributes extractAttributes = OAuth2Attributes.of(oAuth2Provider, userNameAttributeName, attributes);
+
+        Optional<Member> member = memberRepository.findByUsername(extractAttributes.getOauth2UserInfo().getIdentifierKey());
+        if(!member.isPresent()){
+            log.info("존재하지 않음");
+
+            Member createdMember = memberRepository.save(extractAttributes.toEntity(oAuth2Provider, extractAttributes.getOauth2UserInfo()));
+            return new CustomOAuth2User(
+                    createdMember.getAuthorities(),
+                    attributes,
+                    extractAttributes.getNameAttributeKey(),
+                    createdMember.getUsername(),
+                    createdMember.getRole()
+            );
+        }else{
+            return new CustomOAuth2User(
+                    member.get().getAuthorities(),
+                    attributes,
+                    extractAttributes.getNameAttributeKey(),
+                    member.get().getUsername(),
+                    member.get().getRole()
+            );
+        }
+    }
+
+    private OAuth2Provider getSocialType(String registrationId) {
+        log.info("getSocialType의 메서드 : " + registrationId);
+        if(NAVER.equals(registrationId)) {
+            return OAuth2Provider.NAVER;
+        }
+        if(KAKAO.equals(registrationId)) {
+            return OAuth2Provider.KAKAO;
+        }
+        return OAuth2Provider.GOOGLE;
+    }
+
+
+
+
+
+
+}

--- a/src/main/java/com/teamh/khumon/service/JwtProviderService.java
+++ b/src/main/java/com/teamh/khumon/service/JwtProviderService.java
@@ -20,9 +20,8 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.Optional;
 
-@Service
-@RequiredArgsConstructor
 @Slf4j
+@Service
 public class JwtProviderService {
 
     @Value("${jwt.secret}")

--- a/src/main/java/com/teamh/khumon/service/MemberDetailsService.java
+++ b/src/main/java/com/teamh/khumon/service/MemberDetailsService.java
@@ -11,8 +11,8 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Slf4j
-@Service
 @RequiredArgsConstructor
+@Service
 public class MemberDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #10 , #9 

## 예상 리뷰 시간
20-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
카카오, 구글, 네이버 소셜 로그인 인증을 구현하였습니다. 
카카오 : http://localhost:8080/oauth2/authorization/kakao
네이버 : http://localhost:8080/oauth2/authorization/naver
구글 : http://localhost:8080/oauth2/authorization/google
로 요청을 보내면 각 벤더의 로그인 화면이 출력되고, 정상적으로 로그인되었다면 프론트엔드 서버로 리다이렉트 됩니다. 자세한 사항은 스크린샷을 살펴봐주세요.
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="648" alt="스크린샷 2023-10-13 오후 9 50 46" src="https://github.com/KHUMON-EDU/Backend/assets/62254434/6d9fe229-4dda-4297-b6c2-86275e6667c9">
위 처럼 localhost:3000/oauth2/login?id={:memberId}&access-token={:jwt}로 리다이렉트 됩니다. 최대한 스프링 시큐리티의 OAuth2 라이브러리를 활용하고자 하였습니다. 
https://blog.yjyoon.dev/flutter/2021/11/27/flutter-05/
를 참고해 주세요.
