### PR TITLE
feat: ai 서버 응답 엔티티 영속화

### DIFF
--- a/src/main/java/com/teamh/khumon/configuration/WebSecurityConfiguration.java
+++ b/src/main/java/com/teamh/khumon/configuration/WebSecurityConfiguration.java
@@ -65,6 +65,8 @@ public class WebSecurityConfiguration {
         return http.build();
     }
 
+
+    
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> {

--- a/src/main/java/com/teamh/khumon/domain/LearningMaterial.java
+++ b/src/main/java/com/teamh/khumon/domain/LearningMaterial.java
@@ -28,12 +28,8 @@ public class LearningMaterial extends BaseEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-    @Column
-    private String script;
-
-    @Column
+    @Column(columnDefinition = "TEXT")
     private String summary;
-
 
     @Enumerated(EnumType.STRING)
     private MediaFileType mediaFileType;

--- a/src/main/java/com/teamh/khumon/domain/Question.java
+++ b/src/main/java/com/teamh/khumon/domain/Question.java
@@ -7,6 +7,7 @@ import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder

--- a/src/main/java/com/teamh/khumon/dto/AIResponse.java
+++ b/src/main/java/com/teamh/khumon/dto/AIResponse.java
@@ -1,0 +1,16 @@
+package com.teamh.khumon.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class AIResponse {
+    private String summary;
+    private List<Problem> problems;
+}

--- a/src/main/java/com/teamh/khumon/dto/Problem.java
+++ b/src/main/java/com/teamh/khumon/dto/Problem.java
@@ -1,0 +1,18 @@
+package com.teamh.khumon.dto;
+
+
+import lombok.*;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Builder
+public class Problem {
+
+    private Long problem_no;
+    private String answer;
+    private String question;
+
+}

--- a/src/main/java/com/teamh/khumon/repository/AnswerRepository.java
+++ b/src/main/java/com/teamh/khumon/repository/AnswerRepository.java
@@ -1,0 +1,7 @@
+package com.teamh.khumon.repository;
+
+import com.teamh.khumon.domain.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+}

--- a/src/main/java/com/teamh/khumon/service/QuestionAnswerService.java
+++ b/src/main/java/com/teamh/khumon/service/QuestionAnswerService.java
@@ -1,0 +1,49 @@
+package com.teamh.khumon.service;
+
+import com.teamh.khumon.domain.Answer;
+import com.teamh.khumon.domain.LearningMaterial;
+import com.teamh.khumon.domain.Member;
+import com.teamh.khumon.domain.Question;
+import com.teamh.khumon.dto.AIResponse;
+import com.teamh.khumon.dto.Problem;
+import com.teamh.khumon.repository.AnswerRepository;
+import com.teamh.khumon.repository.QuestionRepository;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class QuestionAnswerService {
+
+    private final QuestionRepository questionRepository;
+
+    private final AnswerRepository answerRepository;
+
+    @Transactional
+    public List<Question> saveQuestionAndAnswer(AIResponse aiResponse, Member member, LearningMaterial learningMaterial){
+        List<Problem> problems = aiResponse.getProblems();
+        List<Question> questions = new ArrayList<>();
+        for(Problem problem : problems){
+            Question question = new Question();
+            question.setMember(member);
+            question.setLearningMaterial(learningMaterial);
+            question.setContent(problem.getQuestion());
+            questionRepository.save(question);
+            Answer answer = new Answer();
+            answer.setAnswer(problem.getAnswer());
+            answer.setQuestion(question);
+            answerRepository.save(answer);
+            question.setAnswer(answer);
+            questions.add(question);
+        }
+        return questions;
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #44 

## 예상 리뷰 시간
20-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
AI 서버로부터 전달받은 응답 값을 DTO로 파싱하고, 도메인 엔티티에 영속화하는 비지니스 로직을 작성하였습니다. 
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
