### PR TITLE
feat: offset pagination을 통한 전체 강의내역 조회

### DIFF
--- a/src/main/java/com/teamh/khumon/controller/LearningMaterialController.java
+++ b/src/main/java/com/teamh/khumon/controller/LearningMaterialController.java
@@ -2,6 +2,9 @@ package com.teamh.khumon.controller;
 
 import com.teamh.khumon.service.LearningMaterialService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -31,6 +34,15 @@ public class LearningMaterialController {
     public ResponseEntity<?> getLearningMaterial(@PathVariable(name = "learningMaterialId") Long id, Principal principal){
         return learningMaterialService.getLearningMaterial(id, principal);
     }
+
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/learning-materials") //
+    public ResponseEntity<?> getLearningMaterials(Principal principal, @PageableDefault(sort = "id", direction = Sort.Direction.DESC, size = 10) Pageable pageable, @RequestParam(required = false, defaultValue = "") String search){
+        return learningMaterialService.getLearningMaterials(principal, pageable, search);
+    }
+
+
 
 
 }

--- a/src/main/java/com/teamh/khumon/dto/LearningMaterialContent.java
+++ b/src/main/java/com/teamh/khumon/dto/LearningMaterialContent.java
@@ -1,0 +1,21 @@
+package com.teamh.khumon.dto;
+
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Builder
+public class LearningMaterialContent {
+
+    private String title;
+    private String content;
+    private LocalDateTime createAt;
+    private LocalDateTime modifiedAt;
+
+}

--- a/src/main/java/com/teamh/khumon/dto/LearningMaterialResponse.java
+++ b/src/main/java/com/teamh/khumon/dto/LearningMaterialResponse.java
@@ -19,7 +19,6 @@ public class LearningMaterialResponse {
     private String mediaFileType;
     private LocalDateTime createdDateTime;
     private LocalDateTime modifiedDateTime;
-    private String script;
     private String summary;
     private List<QuestionInformation> questionInformations;
 

--- a/src/main/java/com/teamh/khumon/dto/OffsetPagination.java
+++ b/src/main/java/com/teamh/khumon/dto/OffsetPagination.java
@@ -1,0 +1,24 @@
+package com.teamh.khumon.dto;
+
+
+import lombok.*;
+
+import java.util.List;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class OffsetPagination {
+    private List<LearningMaterialContent> content;
+    private Long totalElements;
+    private Integer totalPages;
+    private Integer size;
+    private Integer pageNumber;
+    private Integer numberOfElements;
+    private Boolean isFirst;
+    private Boolean isLast;
+    private Boolean isEmpty;
+}

--- a/src/main/java/com/teamh/khumon/repository/LearningMaterialRepository.java
+++ b/src/main/java/com/teamh/khumon/repository/LearningMaterialRepository.java
@@ -1,7 +1,11 @@
 package com.teamh.khumon.repository;
 
 import com.teamh.khumon.domain.LearningMaterial;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LearningMaterialRepository extends JpaRepository<LearningMaterial, Long> {
+
+    Page<LearningMaterial> findByMemberIdAndTitleContainingOrContentContaining(Long memberId, String title, String content, Pageable pageable);
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #47 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
사용자의 전체 강의자료를 조회할 수 있는 엔드포인트 생성 및 알고리즘을 구현하였습니다. 
상세 명세서는 노션을 참고해주세용~
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
